### PR TITLE
account: Add condition to check if a line is reconciled before attempting to reconcile it when posting a move [CUSTOM]

### DIFF
--- a/move.py
+++ b/move.py
@@ -455,7 +455,8 @@ class Move(ModelSQL, ModelView):
                         line.id,
                         where=reduce_ids(line.move, sub_moves_ids)
                         & (line.debit == Decimal(0))
-                        & (line.credit == Decimal(0))))
+                        & (line.credit == Decimal(0))
+                        & (line.reconciliation == Null)))
                 to_reconcile.extend(l for l, in cursor)
 
         for move in moves:


### PR DESCRIPTION
Fix #PJAZZ-703

When cancelling a move through the move cancellation wizard, we reconcile the lines and then post the generated cancellation move. However, when posting the move, we currently try to reconcile lines on which there is no credit/debit, which results in an error because these lines have already been reconciled in the previous step.