### PR TITLE
account: [2.12] Add condition to check if a line is reconciled before attempting to reconcile it when posting a move [CUSTOM]

### DIFF
--- a/move.py
+++ b/move.py
@@ -439,7 +439,8 @@ class Move(ModelSQL, ModelView):
                 return l.party, l.account
             to_reconcile = [l for l in move.lines
                 if ((l.debit == l.credit == Decimal('0'))
-                    and l.account.reconcile)]
+                    and l.account.reconcile
+                    and not l.reconciliation)]
             to_reconcile = sorted(to_reconcile, key=keyfunc)
             reconciliations += [
                 list(x) for _, x in groupby(to_reconcile, keyfunc)]


### PR DESCRIPTION
Fix #PJAZZ-703

When cancelling a move through the move cancellation wizard, we reconcile the lines and then post the generated cancellation move. However, when posting the move, we currently try to reconcile lines on which there is no credit/debit, which results in an error because these lines have already been reconciled in the previous step.